### PR TITLE
Use sqlite3 for development

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,7 @@ gem 'sdoc', '0.4.0', group: :doc
 
 group :development do
   gem 'spring',  '1.1.3'
+  gem 'sqlite3'
 end
 
 group :production do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -112,6 +112,7 @@ GEM
       actionpack (>= 3.0)
       activesupport (>= 3.0)
       sprockets (~> 2.8)
+    sqlite3 (1.3.10)
     thor (0.19.1)
     thread_safe (0.3.4)
     tilt (1.4.1)
@@ -148,6 +149,7 @@ DEPENDENCIES
   sass-rails (~> 4.0.3)
   sdoc (= 0.4.0)
   spring (= 1.1.3)
+  sqlite3
   turbolinks
   uglifier (>= 1.3.0)
   unicorn (= 4.8.3)

--- a/config/database.yml
+++ b/config/database.yml
@@ -22,11 +22,8 @@ default: &default
   pool: 5
 
 development:
-  <<: *default
-  database: <%= ENV['salty_database_dev'] %>
-  pool: 5
-  username: <%= ENV['salty_user'] %>
-  password: <%= ENV['salty_password'] %>
+  adapter: sqlite3
+  database: db/development.sqlite3
 
   # Schema search path. The server defaults to $user,public
   #schema_search_path: myapp,sharedapp,public
@@ -41,11 +38,8 @@ development:
 # re-generated from your development database when you run "rake".
 # Do not set this db to the same as development or production.
 test:
-  <<: *default
-  database: <%= ENV['salty_database_test'] %>
-  pool: 5
-  username: <%= ENV['salty_user'] %>
-  password: <%= ENV['salty_password'] %>
+  adapter: sqlite3
+  database: db/test.sqlite3
 
 # As with config/secrets.yml, you never want to store sensitive information,
 # like your database password, in your source code. If your source code is


### PR DESCRIPTION
don't feel obligated to merge this, but while setting up a dev environment i found it miles faster to make this change and just use sqlite3 than to get set up a postgres database and user and env variables and all that.

it doesn't look like you're using json columns anymore, so it doesn't seem to be a necessity to use postgres for development anymore, but correct me if i'm wrong here.
