### PR TITLE
Refactor quotes api/routes

### DIFF
--- a/app/controllers/api/quotes_controller.rb
+++ b/app/controllers/api/quotes_controller.rb
@@ -1,25 +1,33 @@
 class Api::QuotesController < Api::ApplicationController
+  before_action :set_user
+  before_action :check_for_quotes
 
-  def text_show
-    user = User.find_by(twitch_name: params[:user]) || false
-    if user
-      u_quotes = user.quotes
-      if u_quotes.length == 0
-        render status: 400, json: {status: 400, error: "No quotes for this user."}
-        return
-      end
-      r_quote_array = []
-      num_used = []
-      limit = params[:limit] || 1
-      limit.times {num_used.push(rand(u_quotes.length))}
-      num_used.each do |x| 
-        r_quote_array.push(u_quotes[x].text)
-      end
-      render status: 200, json: {status: 200, text: r_quote_array}
-    else
+  def index
+    render status: 200, json: {
+      status: 200,
+      quotes: @user.quotes.sample(limit).map { |quote| {text: quote.text} }
+    }
+  end
+
+  private
+
+  def set_user
+    unless @user = User.find_by(twitch_name: params[:user_id])
       render status: 400, json: {status: 400, error: "Invalid user."}
     end
   end
 
+  def check_for_quotes
+    if @user.quotes.empty?
+      render status: 400, json: {status: 400, error: "No quotes for this user."}
+    end
+  end
 
+  def limit
+    if params[:limit].present?
+      params[:limit].to_i < 0 ? 0 : params[:limit].to_i
+    else
+      1
+    end
+  end
 end

--- a/app/models/quote.rb
+++ b/app/models/quote.rb
@@ -1,2 +1,3 @@
 class Quote < ActiveRecord::Base
+  belongs_to :user
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,7 +22,9 @@ Rails.application.routes.draw do
 
   # API Stuff
   namespace :api do
-    get   'quote', to: 'quotes#text_show',    as: :text_show
+    resources :users, only: [] do
+      resources :quotes, only: [:index]
+    end
 
     get   'song', to: 'songs#song_show',    as: :song_show
     post  'song', to: 'songs#song_update',  as: :song_update


### PR DESCRIPTION
# I didn't mean to write this much I swear

This refactored most of the quotes endpoint and I just wanted to explain why I felt each of these changes was good. You can feel free to pick and choose which ones you'd like, if some of them don't sit well with you.
## Changes visible to consumers of this endpoint
### Route

Moves the route for quotes from `/api/quote?user=batedurgonnadie` to `/api/users/batedurgonnadie/quotes` (more on `quote` vs. `quotes` later). Making the hierarchy of the route reflect the relationship (a user owns a quote) makes it more clear what's going on when looking at the URI. It also is easy to see that a username is mandatory, where query parameters imply optionality.
### Response

The response for a successful hit to this endpoint changes from 

``` json
{
  "status": 200,
  "text": [
    "quote1",
    "quote2",
    "quote3"
  ]
}
```

to

``` json
{
  "status": 200,
  "quotes": [
    {"text": "quote1"},
    {"text": "quote2"},
    {"text": "quote3"}
  ]
}
```

I know this seems convoluted at first, but this allows for expansion later if you want to start treating quotes as _objects_ in responses, not just strings. e.g. if you want to add an `author` field or a `last_used` field, those fields would fit nicely into this response, where trying to put them into the array of strings would be messy without restructuring. This is one of a few standard ways of returning arrays of objects in APIs, and generally matches the typical response you'd expect a generic Rails application to give for an endpoint at this URI.
## Innards-only changes
### Move input handling into `before_action` callbacks

It's nice to keep your controller actions very small so that you can very clearly see at a glance what it's doing, and to push some of the legwork of assigning users from ids and checking for valid input into `before_action` callback methods (which can then be easily reused by other actions and controllers).
### Resourceful routing

Rails comes prebaked with all the logic to handle resourceful routing, i.e. routes that correspond directly (or mostly directly) to ActiveModel records in the db. It's handy and fast to define routes manually with `get '/path/to/thing'` and `post '/path/to/things'` but once you start to get a lot of these, the routes file becomes really hard to process in your head.

``` ruby
resources :users, only: [] do # `only: []` means we're not actually generating any routes directly for `/users`
  resources :quotes, only: [:index] # generate a `/users/quotes` route, which is a predefined behavior for how Rails treats the `:index` type route for a resource
end
```

This also sort of forces you to use the seven generic Rails controller method names (which is why `text_show` was renamed to `index`), which is good for letting other people easily recognize what's going on in your application's source, and for forcing you to think about splitting up controllers when a new action doesn't cleanly fit into one.

if this doesn't make any sense to you look over http://guides.rubyonrails.org/routing.html
if it still doesn't make sense yet, don't merge it. It's better to have code that you understand than perfect code.
### `quote` vs. `quotes` in the URI

I think that, since this endpoint returns an array of things (even if the default length of the array is 1), the URI should be plural. This also comes with resourceful routing, which sets the convention that under most circumstances these things should be plural (in the URL and in controller names).
## Note on serializers

if you want external services to be able to safely consume this API, you may want to think about using some sort of strict versioning and ActiveModel serializers. That `.map` call I put in QuotesController is going to start getting stinky quickly if you want to both (a) change stuff and (b) maintain backwards compatibility. If you don't care about external applications and you just care about salty_bot himself, then you don't have to worry about this.
